### PR TITLE
Fix name os kainoscore-static-files name in locals.tf

### DIFF
--- a/aws/prod-infra/global/ssm-parameters.tf
+++ b/aws/prod-infra/global/ssm-parameters.tf
@@ -31,7 +31,7 @@ resource "aws_ssm_parameter" "s3_app_kfd_files" {
 resource "aws_ssm_parameter" "s3_app_static_files" {
   name  = "/s3/kcappstaticfiles"
   type  = "String"
-  value = "kainoscore-static-files"
+  value = "kainoscore-staticfiles"
 }
 
 resource "aws_ssm_parameter" "s3_app_zip_files" {

--- a/aws/prod-infra/prod/locals.tf
+++ b/aws/prod-infra/prod/locals.tf
@@ -2,7 +2,7 @@ locals {
   cloudfront_comment                     = "Core Distribution ${var.env}"
   s3_bucket_kfd_name                     = "kainoscore-kfdfiles-${var.env}"
   s3_bucket_zip_files_name               = "kainoscore-zip-files-${var.env}"
-  s3_bucket_static_files_name            = "kainoscore-staticfiles-${var.env}"
+  s3_bucket_static_files_name            = "kainoscore-static-files-${var.env}"
   s3_bucket_submitted_form_data_name     = "kainoscore-submitted-form-data-${var.env}"
   s3_bucket_core_audit_logs_name         = "kainoscore-audit-logs-${var.env}"
   dynamodb_core_form_sessions_table_name = "Core_FormSessions_${var.env}"

--- a/aws/prod-infra/prod/locals.tf
+++ b/aws/prod-infra/prod/locals.tf
@@ -2,7 +2,7 @@ locals {
   cloudfront_comment                     = "Core Distribution ${var.env}"
   s3_bucket_kfd_name                     = "kainoscore-kfdfiles-${var.env}"
   s3_bucket_zip_files_name               = "kainoscore-zip-files-${var.env}"
-  s3_bucket_static_files_name            = "kainoscore-static-files-${var.env}"
+  s3_bucket_static_files_name            = "kainoscore-staticfiles-${var.env}"
   s3_bucket_submitted_form_data_name     = "kainoscore-submitted-form-data-${var.env}"
   s3_bucket_core_audit_logs_name         = "kainoscore-audit-logs-${var.env}"
   dynamodb_core_form_sessions_table_name = "Core_FormSessions_${var.env}"


### PR DESCRIPTION
On checking ssm parameters noticed locals.tf required an extra "-" between kainoscore-staticfiles so now matches  kainoscore-static-files, where new deploy-to-prod will add -prod environment to the s3 bucket being created. 